### PR TITLE
Remove trailing slash from source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module which creates ECS resource on Flexible Engine
 
 ```hcl
 module "ecs_cluster" {
-  source = "FlexibleEngineCloud/ecs/flexibleengine/"
+  source = "FlexibleEngineCloud/ecs/flexibleengine"
 
   instance_name  = "my-cluster"
   instance_count = 2


### PR DESCRIPTION
Copying the former example from the README.md file caused a Terraform error:
```
│ Error: Module not found
│
│ The module address "FlexibleEngineCloud/ecs/flexibleengine/" could not be resolved.
│
│ If you intended this as a path relative to the current module, use "./FlexibleEngineCloud/ecs/flexibleengine/" instead. The "./" prefix indicates that the address is a relative
│ filesystem path.
```

This was caused by the trailing slash in the source value:
`source = "FlexibleEngineCloud/ecs/flexibleengine/"`