### PR TITLE
Add dedicated host deployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ module "ecs_cluster" {
     }
   ]
 
+  scheduler_hints = [
+    {
+      group = ""
+      tenancy = "dedicated" #shared/dedicated
+      deh_id = "my-dedicated-host-id"
+    }
+  ]
+
   tags = {
     Environment = "dev"
   }
@@ -140,7 +148,7 @@ inputs = {
 | subnet\_id | The subnet ID to launch in | `string` | `""` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | user\_data | The user data to provide when launching the instance | `string` | `""` | no |
-| scheduler\_hints | List of hints on how the instance should be launched | <pre>list(object({<br>   group              = string<br>   different_host     = string<br>   same_host          = string<br>   query              = string<br>   target_cell        = string<br>   build_near_host_ip = string<br>   tenancy            = string<br>   dedicated_host_id  = string<br>   }))</pre> | n/a | yes |
+| scheduler\_hints | List of hints on how the instance should be launched | <pre>list(object({<br>   group      = string<br>   tenancy    = string<br>   deh_id     = string<br>   }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ module "ecs_cluster" {
 
   scheduler_hints = [
     {
-      group = ""
+      group   = ""
       tenancy = "dedicated" #shared/dedicated
-      deh_id = "my-dedicated-host-id"
+      deh_id  = "my-dedicated-host-id"
     }
   ]
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ inputs = {
 | subnet\_id | The subnet ID to launch in | `string` | `""` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | user\_data | The user data to provide when launching the instance | `string` | `""` | no |
+| scheduler\_hints | List of hints on how the instance should be launched | <pre>list(object({<br>   group              = string<br>   different_host     = string<br>   same_host          = string<br>   query              = string<br>   target_cell        = string<br>   build_near_host_ip = string<br>   tenancy            = string<br>   dedicated_host_id  = string<br>   }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -41,14 +41,9 @@ resource "flexibleengine_compute_instance_v2" "instances" {
   dynamic "scheduler_hints" {
     for_each = var.scheduler_hints
     content {
-      group              = scheduler_hints.value.group != "" ? scheduler_hints.value.group : null
-      different_host     = length(scheduler_hints.value.different_host) > 0 ? scheduler_hints.value.different_host : null
-      same_host          = length(scheduler_hints.value.same_host) > 0 ? scheduler_hints.value.same_host : null
-      query              = length(scheduler_hints.value.query) > 0 ? scheduler_hints.value.query : null
-      target_cell        = scheduler_hints.value.target_cell != "" ? scheduler_hints.value.target_cell : null
-      build_near_host_ip = scheduler_hints.value.build_near_host_ip != "" ? scheduler_hints.value.build_near_host_ip : null
-      tenancy            = scheduler_hints.value.tenancy != "" ? scheduler_hints.value.tenancy : null
-      dedicated_host_id  = scheduler_hints.value.dedicated_host_id != "" ? scheduler_hints.value.dedicated_host_id : null
+      group   = scheduler_hints.value.group != "" ? scheduler_hints.value.group : null
+      tenancy = scheduler_hints.value.tenancy != "" ? scheduler_hints.value.tenancy : null
+      deh_id  = scheduler_hints.value.deh_id != "" ? scheduler_hints.value.deh_id : null
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,8 @@ resource "flexibleengine_compute_instance_v2" "instances" {
       query              = length(scheduler_hints.value.query) > 0 ? scheduler_hints.value.query : null
       target_cell        = scheduler_hints.value.target_cell != "" ? scheduler_hints.value.target_cell : null
       build_near_host_ip = scheduler_hints.value.build_near_host_ip != "" ? scheduler_hints.value.build_near_host_ip : null
+      tenancy            = scheduler_hints.value.tenancy != "" ? scheduler_hints.value.tenancy : null
+      dedicated_host_id  = scheduler_hints.value.dedicated_host_id != "" ? scheduler_hints.value.dedicated_host_id : null
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "eip_bandwidth" {
 variable "existing_eip" {
   description = "Existing IPs (public IPs) to be attached to ECS"
   default     = []
-  type        = list
+  type        = list(any)
 }
 
 variable "ext_net_name" {
@@ -145,8 +145,8 @@ variable "scheduler_hints" {
   description = "Provide the Nova scheduler with hints on how the instance should be launched"
   default     = []
   type = list(object({
-    group              = string
-    tenancy            = string
+    group   = string
+    tenancy = string
     deh_id  = string
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -151,5 +151,7 @@ variable "scheduler_hints" {
     query              = list(string)
     target_cell        = string
     build_near_host_ip = string
+    tenancy            = string
+    dedicated_host_id  = string
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -146,12 +146,7 @@ variable "scheduler_hints" {
   default     = []
   type = list(object({
     group              = string
-    different_host     = list(string)
-    same_host          = list(string)
-    query              = list(string)
-    target_cell        = string
-    build_near_host_ip = string
     tenancy            = string
-    dedicated_host_id  = string
+    deh_id  = string
   }))
 }


### PR DESCRIPTION
This PR follows 1.31 provider update adding the option to deploy an ECS to a dedicated host.
Changes are :
- Added options to sheduler_hints:
  - tenancy = SHARED / DEDICATED
  - deh_id = UUID of dedicated host
- Removed deprecated options for scheduler_hints 